### PR TITLE
[Issue #12] Bump Velocity from 1.17 to 2.3 because of CVE-2020-13936

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,8 +412,8 @@
               </dependency>
               <dependency>
                 <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>1.7</version>
+                <artifactId>velocity-core</artifactId>
+                <version>2.3</version>
               </dependency>
             </dependencies>
 			</plugin>


### PR DESCRIPTION
This is just a version bump. I could not get this project to compile, because of:

- Dependency [org.apache.maven.plugins:maven-source-plugin:3.0.1-CIBET](https://github.com/Wolfgang-Winter/cibet/blob/7867e43d77876a170539a5a1e42cf5f4927e9a91/pom.xml#L378) (this is not available on Maven Central)
- A [command line argument](https://github.com/Wolfgang-Winter/cibet/blob/7867e43d77876a170539a5a1e42cf5f4927e9a91/pom.xml#L361) for maven-surefire-plugin that contains hard-coded Windows path names
- An [Oracle JDBC dependency in cibet-integrationtest](https://github.com/Wolfgang-Winter/cibet/blob/7867e43d77876a170539a5a1e42cf5f4927e9a91/cibet-integrationtest/pom.xml#L267) that is not available on Maven Central

So please beware that this is very untested! 😀